### PR TITLE
Update colour language

### DIFF
--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -1,5 +1,7 @@
 @import './colour-palette'; // This is needed for storybook
 
+$cads-language__brand-primary: $cads-palette__heritage-blue;
+$cads-language__brand-secondary: $cads-palette__heritage-yellow;
 $cads-language__text-colour: $cads-palette__black;
 $cads-language__secondary-text-colour: $cads-palette__dark-grey;
 $cads-language__link-colour: $cads-palette__heritage-blue;
@@ -7,7 +9,7 @@ $cads-language__link-hover-colour: $cads-palette__heritage-blue-dark;
 $cads-language__link-hover-background-colour: $cads-palette__blue-light;
 $cads-language__link-visited-colour: $cads-palette__purple;
 $cads-language__link-active-colour: $cads-palette__dark-grey;
-$cads-language__focus-colour: $cads-palette__heritage-yellow;
+$cads-language__focus-colour: $cads-palette__yellow;
 $cads-language__focus-text-colour: $cads-palette__black;
 $cads-language__input-border-colour: $cads-palette__mid-grey;
 $cads-language__border-colour: $cads-palette__light-grey;
@@ -19,6 +21,8 @@ $cads-language__button-colour: $cads-palette__heritage-blue;
 :export {
     /* prettier-ignore */
     language: {
+        brandPrimary: $cads-language__brand-primary;
+        brandSecondary: $cads-language__brand-secondary;
         textColour: $cads-language__text-colour;
         secondaryTextColour: $cads-language__secondary-text-colour;
         linkColour: $cads-language__link-colour;

--- a/scss/1-settings/_colour-palette.scss
+++ b/scss/1-settings/_colour-palette.scss
@@ -1,13 +1,14 @@
 /* stylelint-disable */
-$cads-palette__heritage-blue: #004291;
+$cads-palette__heritage-blue: #004B88;
 $cads-palette__heritage-blue-dark: #012760;
 $cads-palette__blue-light: #f2f8ff;
-$cads-palette__heritage-yellow: #ffd250;
+$cads-palette__heritage-yellow: #FCBB69;
 $cads-palette__heritage-blue-40: #97a8cc;
 $cads-palette__heritage-yellow-40: #fde5c4;
 $cads-palette__purple: #a33e89;
 $cads-palette__red: #df3034;
 $cads-palette__red-light: #fae1e1;
+$cads-palette__yellow: #FFD250;
 $cads-palette__black: #161616;
 $cads-palette__dark-grey: #4a4e4f;
 $cads-palette__mid-grey: #8d9093;

--- a/styleguide/styles.scss
+++ b/styleguide/styles.scss
@@ -7,19 +7,21 @@
 }
 
 .cads-styleguide__colour-tile {
-    height: 125px;
-    width: 125px;
-    border-radius: 100%;
-    border: solid 1px #000;
-    display: inline-block;
-    text-align: center;
+    display: inline-grid;
     margin: 1em;
+    width: 80px;
+
+    .cads-styleguide__colour-tile-bg {
+        height: 48px;
+        width: 48px;
+        border-radius: 100%;
+        border: solid 1px #000;
+    }
 
     p {
         font-size: 0.75em;
-        line-height: 1em;
-        margin: calc(50% - 1em) 0 0 0;
-        padding: 0;
+        line-height: 1.25em;
+        padding: 8px 0 0 0;
     }
 }
 

--- a/styleguide/tokens.stories.js
+++ b/styleguide/tokens.stories.js
@@ -43,8 +43,9 @@ function getColours(type, sass) {
     colours.forEach(item => {
         const name = item.replace(`${type}-`, '');
         const colour = sass[item];
-        result += `<div class="cads-styleguide__colour-tile" style="background: ${colour}">
-<p style="color: ${getBrightness(colour)}">${name.replace(
+        result += `<div class="cads-styleguide__colour-tile">
+<div class="cads-styleguide__colour-tile-bg" style="background: ${colour}"></div>
+<p>${name.replace(
             /([A-Z])/g,
             g => `-${g[0].toLowerCase()}`
         )}


### PR DESCRIPTION
In the design system meeting, we discussed keeping the original heritage yellow for components that are not focus. This pull request adds the brand colours to the colour language as primary (heritage blue) and secondary (heritage yellow) and adds a yellow to the palette for focus colours.

Also updated the display of the colour language and palette pages on storybook as the larger blue circles were getting difficult with so many options. 

 

